### PR TITLE
SIREN et SIRET non-diffusables

### DIFF
--- a/source/includes/_entreprises.md.erb
+++ b/source/includes/_entreprises.md.erb
@@ -141,7 +141,7 @@ Le JSON de retour est composé de trois clés :
 * `gateway_error` indique si un des fournisseurs de données n'a pas
   correctement fonctionné.
 
-Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non-diffusables](#siren-et-siret-non-diffusables) pour plus de détails.
+Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusés à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
 
 ### Entreprise
 

--- a/source/includes/_entreprises.md.erb
+++ b/source/includes/_entreprises.md.erb
@@ -141,7 +141,7 @@ Le JSON de retour est composé de trois clés :
 * `gateway_error` indique si un des fournisseurs de données n'a pas
   correctement fonctionné.
 
-Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusés à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
+Cette API est susceptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusés à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
 
 ### Entreprise
 

--- a/source/includes/_entreprises.md.erb
+++ b/source/includes/_entreprises.md.erb
@@ -141,6 +141,8 @@ Le JSON de retour est composé de trois clés :
 * `gateway_error` indique si un des fournisseurs de données n'a pas
   correctement fonctionné.
 
+Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non-diffusables](#siren-et-siret-non-diffusables) pour plus de détails.
+
 ### Entreprise
 
 La liste exhaustive des champs renvoyés est disponible dans l'exemple ci-contre.

--- a/source/includes/_errors.md.erb
+++ b/source/includes/_errors.md.erb
@@ -8,7 +8,7 @@ Error Code | Meaning
 206        | Réponse incomplete - Un des fournisseurs de données a renvoyé une erreur, la réponse est incomplète (les valeurs concernées contiennent le message par défaut: `Donnée indisponible`)
 400        | Mauvaise requête -- Le format de la requête est incorrecte
 401        | Non autorisé -- Token invalide ou manquant
-403        | Interdit -- Votre jeton ne vous donne pas accès à cette ressource
+403        | Interdit -- Votre jeton ne vous donne pas accès à cette ressource (cas particulier des entreprises [non-diffusables](#siren-et-siret-non-diffusables))
 404        | Non trouvé -- La ressource (l'entreprise, le certificat, ...) demandée n'a pas été trouvée
 422        | Entité non traitable -- Le format de la donnée passée en paramètre n'est pas accepté
 500        | Erreur interne -- Une erreur interne est survenue

--- a/source/includes/_errors.md.erb
+++ b/source/includes/_errors.md.erb
@@ -8,7 +8,7 @@ Error Code | Meaning
 206        | Réponse incomplete - Un des fournisseurs de données a renvoyé une erreur, la réponse est incomplète (les valeurs concernées contiennent le message par défaut: `Donnée indisponible`)
 400        | Mauvaise requête -- Le format de la requête est incorrecte
 401        | Non autorisé -- Token invalide ou manquant
-403        | Interdit -- Votre jeton ne vous donne pas accès à cette ressource (cas particulier des entreprises [non-diffusables](#siren-et-siret-non-diffusables))
+403        | Interdit -- Votre jeton ne vous donne pas accès à cette ressource (cas particulier des entreprises [non diffusés à tous](#siren-et-siret-non-diffus-s-tous))
 404        | Non trouvé -- La ressource (l'entreprise, le certificat, ...) demandée n'a pas été trouvée
 422        | Entité non traitable -- Le format de la donnée passée en paramètre n'est pas accepté
 500        | Erreur interne -- Une erreur interne est survenue

--- a/source/includes/_non_diffusable.md.erb
+++ b/source/includes/_non_diffusable.md.erb
@@ -1,6 +1,6 @@
-# SIREN et SIRET non-diffusables
+# SIREN et SIRET non diffusés à tous
 
-> Exemple de message d'erreur renvoyé avec un SIREN ou SIRET non-diffusable :
+> Exemple de message d'erreur renvoyé avec un SIREN ou SIRET non diffusés à tous :
 
 ```json
 {
@@ -14,15 +14,15 @@
 Certains appels pourront renvoyer un code HTTP 403 signifiant signifiant que l'accès à la resource (entreprise ou établissement) est interdit. Cela peut signifier deux choses :
 
 - le cas général signifie que votre jeton ne vous permet pas d'accéder à l'API en question
-- cependant pour les APIs `/entreprises` et `/etablissements` certaines entités ont demandés à être non-diffusables, dans ce cas nous renvoyons un code 403 car l'accès à la ressource est en effet interdite par l'INSEE.
+- cependant pour les APIs `/entreprises` et `/etablissements` les données de ces entités et établissements ne sont pas diffusées à tous par l'INSEE du fait de leur opposition à ce que leurs données soient utilisées à des fin de prospection, notamment commerciale ; dans ce cas nous renvoyons un code 403 car l'accès à la ressource est en effet interdite par l'INSEE.
 
-### Comment interpréter "non-diffusable"
+### Comment interpréter "non diffusés à tous"
 
-Un numéro de SIRET ou SIREN non-diffusable signifie que l'entreprise ou l'établissement a bel et bien existé à un moment, mais **ne signifie en aucun cas qu'il existe encore aujourd'hui !**
+Un numéro de SIRET ou SIREN non diffusé à tous signifie que l'entreprise ou l'établissement a bel et bien existé à un moment, mais **ne signifie en aucun cas qu'il existe encore aujourd'hui !**
 
 ### Quelles entreprises sont concernées ?
 
-Selon les articles [A123-95](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165032&cidTexte=LEGITEXT000005634379&dateTexte=20100702) et [A123-96](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165030&cidTexte=LEGITEXT000005634379&dateTexte=20100702) peuvent être non-diffusables :
+Selon les articles [A123-95](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165032&cidTexte=LEGITEXT000005634379&dateTexte=20100702) et [A123-96](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165030&cidTexte=LEGITEXT000005634379&dateTexte=20100702) du code du commerce, peuvent être non diffusés à tous :
 
 - certains établissements du ministère de la défense
 - certaines personnes morales pour des raisons de confidentialités

--- a/source/includes/_non_diffusable.md.erb
+++ b/source/includes/_non_diffusable.md.erb
@@ -1,0 +1,29 @@
+# SIREN et SIRET non-diffusables
+
+> Exemple de message d'erreur renvoyé avec un SIREN ou SIRET non-diffusable :
+
+```json
+{
+  "errors": [
+    "Le SIREN ou SIRET est non diffusable"
+  ],
+  "gateway_error": true
+}
+```
+
+Certains appels pourront renvoyer un code HTTP 403 signifiant signifiant que l'accès à la resource (entreprise ou établissement) est interdit. Cela peut signifier deux choses :
+
+- le cas général signifie que votre jeton ne vous permet pas d'accéder à l'API en question
+- cependant pour les APIs `/entreprises` et `/etablissements` certaines entités ont demandés à être non-diffusables, dans ce cas nous renvoyons un code 403 car l'accès à la ressource est en effet interdite par l'INSEE.
+
+### Comment interpréter "non-diffusable"
+
+Un numéro de SIRET ou SIREN non-diffusable signifie que l'entreprise ou l'établissement a bel et bien existé à un moment, mais **ne signifie en aucun cas qu'il existe encore aujourd'hui !**
+
+### Quelles entreprises sont concernées ?
+
+Selon les articles [A123-95](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165032&cidTexte=LEGITEXT000005634379&dateTexte=20100702) et [A123-96](https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=A50D4E549BAC95B63FFE10B24F86D7A5.tplgfr21s_1?idArticle=LEGIARTI000020165030&cidTexte=LEGITEXT000005634379&dateTexte=20100702) peuvent être non-diffusables :
+
+- certains établissements du ministère de la défense
+- certaines personnes morales pour des raisons de confidentialités
+- toute personne physique qui en fait la demande auprès de l'INSEE

--- a/source/includes/_non_diffusable.md.erb
+++ b/source/includes/_non_diffusable.md.erb
@@ -11,10 +11,10 @@
 }
 ```
 
-Certains appels pourront renvoyer un code HTTP 403 signifiant signifiant que l'accès à la resource (entreprise ou établissement) est interdit. Cela peut signifier deux choses :
+Certains appels peuvent renvoyer un code HTTP 403 signifiant que l'accès à la ressource (entreprise ou établissement) est interdit. Cela peut signifier deux choses :
 
 - le cas général signifie que votre jeton ne vous permet pas d'accéder à l'API en question
-- cependant pour les APIs `/entreprises` et `/etablissements` les données de ces entités et établissements ne sont pas diffusées à tous par l'INSEE du fait de leur opposition à ce que leurs données soient utilisées à des fin de prospection, notamment commerciale ; dans ce cas nous renvoyons un code 403 car l'accès à la ressource est en effet interdite par l'INSEE.
+- cependant pour les APIs `/entreprises` et `/etablissements` les données de ces entités ne sont pas diffusées à tous par l'INSEE du fait de leur opposition à ce que leurs données soient utilisées à des fin de prospection, notamment commerciale ; dans ce cas nous renvoyons un code 403 car l'accès à la ressource est en effet interdite par l'INSEE.
 
 ### Comment interpréter "non diffusés à tous"
 

--- a/source/includes/etablissements/_etablissements.md.erb
+++ b/source/includes/etablissements/_etablissements.md.erb
@@ -92,7 +92,7 @@ La liste exhaustive de tous les champs disponibles pour `etablissement` est disp
 
 Les informations d’adresse sont issues des adresses géographiques et normalisées. Nous ne prenons pas en compte l’adresse déclarée. La géolocalisation de l’entreprise peut être faite grâce au service de géocodage suivant : <a href='http://adresse.data.gouv.fr'>http://adresse.data.gouv.fr</a>
 
-Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non-diffusables](#siren-et-siret-non-diffusables) pour plus de détails.
+Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusé à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
 
 ### L'État administratif
 

--- a/source/includes/etablissements/_etablissements.md.erb
+++ b/source/includes/etablissements/_etablissements.md.erb
@@ -92,6 +92,8 @@ La liste exhaustive de tous les champs disponibles pour `etablissement` est disp
 
 Les informations d’adresse sont issues des adresses géographiques et normalisées. Nous ne prenons pas en compte l’adresse déclarée. La géolocalisation de l’entreprise peut être faite grâce au service de géocodage suivant : <a href='http://adresse.data.gouv.fr'>http://adresse.data.gouv.fr</a>
 
+Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non-diffusables](#siren-et-siret-non-diffusables) pour plus de détails.
+
 ### L'État administratif
 
 > Valeurs possibles de l'état administratif pour un établissement

--- a/source/includes/etablissements/_etablissements.md.erb
+++ b/source/includes/etablissements/_etablissements.md.erb
@@ -92,7 +92,7 @@ La liste exhaustive de tous les champs disponibles pour `etablissement` est disp
 
 Les informations d’adresse sont issues des adresses géographiques et normalisées. Nous ne prenons pas en compte l’adresse déclarée. La géolocalisation de l’entreprise peut être faite grâce au service de géocodage suivant : <a href='http://adresse.data.gouv.fr'>http://adresse.data.gouv.fr</a>
 
-Cette API est succeptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusé à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
+Cette API est susceptible de renvoyer un code HTTP 403 même si votre token vous permet d'y accéder, référrez-vous à la section sur les [SIREN et SIRET non diffusé à tous](#siren-et-siret-non-diffus-s-tous) pour plus de détails.
 
 ### L'État administratif
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -22,6 +22,7 @@ includes:
   - entreprises_legacy
   - etablissements
   - etablissements_legacy
+  - non_diffusable
   - extraits_rcs_infogreffe
   - exercices
   - attestation_agefiph


### PR DESCRIPTION
Ajout de : 

- une section complète pour expliquer le code HTTP 403 ainsi que ce qu'il signifie d'un point de vue métier
- un lien vers cette section dans l'API `/entreprises`, `/etablissements` et la sections des erreurs

![Screenshot_2019-06-13 Documentation API Entreprise](https://user-images.githubusercontent.com/5159985/59417228-8031ba00-8dcf-11e9-850b-27e3d37fbaa6.png)
