### PR TITLE
Fix a typo in documentation

### DIFF
--- a/source/includes/_with_insee_v3.md.erb
+++ b/source/includes/_with_insee_v3.md.erb
@@ -24,4 +24,4 @@ Jusqu'au 12 mai 2019, les deux version cohabitent. Par défaut nous servons les 
 
 **À compter du 13 mai 2019 l'API renverra systématiquement les données issues l'API sirene_v3 de l'INSEE, indépendament de la valeur ou la présence du champ `with_insee_v3`, vous avez jusqu'à cette date pour impacter vos services**
 
-Dans la nouvelle mouture, un champ a été ajouté à l'API actuelle ; le champ `etat_adminisratif` (cf JSON renvoyé).
+Dans la nouvelle mouture, un champ a été ajouté à l'API actuelle ; le champ `etat_administratif` (cf JSON renvoyé).


### PR DESCRIPTION
The actual value in the returned data doesn’t have the typo.

👋 