### PR TITLE
Update doc DGFiP (closes #27)

### DIFF
--- a/source/includes/_attestation_fiscale_dgfip.md.erb
+++ b/source/includes/_attestation_fiscale_dgfip.md.erb
@@ -18,14 +18,18 @@ Par exemple si vous demandez une attestation en mars 2015, l’attestation fisca
 
 Exemple de document renvoyé : [Attestation fiscale](files/attestation_fiscale.pdf)
 
-**Périmètre de l'attestation de régularité fiscale**
+### Périmètre de l'attestation de régularité fiscale
+
 L'attestation de régularité fiscale est limitée aux entreprises soumises à l'impôt sur les sociétés (IS) à l'exclusion des :
 
 - bénéfices industriels et commerciaux (BIC)
 - bénéfices non commerciaux (BNC)
 - bénéfices agricoles (BA)
 
-Sont aussi exclues les entreprises soumises à l'impôt sur le revenu (entrepreneurs individuels).
+Sont aussi exclues, même si les obligations fiscales sont respectées :
+
+- entreprises individuelles, sociétés de personnes ou groupements passibles de l'impôt sur le revenu (entrepreneurs individuels)
+- sociétés bénéficiant d’un plan de règlement, redressement, sauvegarde ou conciliation ainsi qu’aux sociétés ayant formulé un recours contentieux assorti d'un sursis de paiement
 
 **Condition de délivrance de l'attestation**
 

--- a/source/includes/_exercices.md.erb
+++ b/source/includes/_exercices.md.erb
@@ -24,17 +24,20 @@
 }
 ```
 
-**Définition du chiffre d'affaire :**
+### Définition du chiffre d'affaire :
 
-Celui porté sur la liasse fiscale qui correspond au chiffre d'affaire comptable.
+Celui porté sur la liasse fiscale qui correspond au chiffre d'affaire comptable :
 
-<aside class="notice">
+- le montant porté en case FL de l’imprimé 2052 (cas du régime réel normal)
+- la somme des montants indiqués dans les cases 210, 214 et 218 du formulaire 2033B (cas du régime réel simplifié)
+
+### Périmètre de l'API
+
 Cet endpoint ne renvoie les chiffres d'affaire que pour les entreprises qui vérifient les conditions suivantes :
-  <ul>
-    <li>L'entreprise est soumise à l'impôt sur les sociétés.</li>
-    <li>L'entreprise à transmis ses comptes annuels aux greffes.</li>
-  </ul>
-</aside>
+
+- Il existe pour cette entreprise **au moins** 3 exercices
+- L'entreprise est soumise à l'impôt sur les sociétés selon les règles des régimes d'imposition réels normal ou simplifié
+- L'entreprise à transmis ses comptes annuels aux greffes
 
 ### Requête HTTP
 `GET https://entreprise.api.gouv.fr/v2/exercices/:siret`

--- a/source/includes/liasses_fiscales_dgfip/_liasses_fiscales_dgfip.md.erb
+++ b/source/includes/liasses_fiscales_dgfip/_liasses_fiscales_dgfip.md.erb
@@ -64,6 +64,17 @@
 
 Ce service renvoie les déclarations de liasses fiscales (restreintes aux formulaires disponibles) d'une entreprise pour une année donnée.
 
+### Périmètre de la liasse fiscale
+
+La liasse fiscale est limitée aux entreprises soumises à :
+
+- l'impôt sur les sociétés (IS)*
+- aux bénéfices industriels et commerciaux (BIC)*
+- aux bénéfices non commerciaux (BNC)*
+- aux bénéfices agricoles (BA)*
+
+\* selon les règles des régimes réels normal ou simplifié
+
 ### Requête HTTP
 
 `GET https://entreprise.api.gouv.fr/v2/liasses_fiscales_dgfip/:annee/declarations/:siren`


### PR DESCRIPTION
À partir de la dernière version documentation fournie par la DGFiP j'ai mis à jour notre documentation pour les 3 APIs de la DGFiP :
- l'attestation fiscale
- les 3 derniers chiffres d'affaires
- la liasse fiscale

C'est pratiquement un copier/coller de la doc. On aurait pu faire ça depuis LONGTEMPS... :/

# Attestation fiscale
![image](https://user-images.githubusercontent.com/5159985/78771439-d2fce380-7998-11ea-9f74-88aa63102ef6.png)

# Exercices
![image](https://user-images.githubusercontent.com/5159985/78771463-db551e80-7998-11ea-945b-d9d45bff37cc.png)

# Liasse fiscale
![image](https://user-images.githubusercontent.com/5159985/78771484-e3ad5980-7998-11ea-90b4-d4cff87bf08d.png)
